### PR TITLE
feat: implement get current user endpoint

### DIFF
--- a/src/routes/users-route.js
+++ b/src/routes/users-route.js
@@ -1,7 +1,25 @@
 import { Elysia, t } from 'elysia';
-import { registerUser, getAllUsers, getUserById, loginUser } from '../services/users-service.js';
+import { registerUser, getAllUsers, getUserById, loginUser, getCurrentUser } from '../services/users-service.js';
 
 export const usersRoute = new Elysia({ prefix: '/api/users' })
+    .get('/current', async ({ request, set }) => {
+        const authHeader = request.headers.get('authorization');
+        
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+            set.status = 401;
+            return { error: 'unauthorized' };
+        }
+
+        const token = authHeader.split(' ')[1];
+
+        try {
+            const user = await getCurrentUser(token);
+            return { data: user };
+        } catch (error) {
+            set.status = 401;
+            return { error: 'unauthorized' };
+        }
+    })
     .post('/login', async ({ body, set }) => {
         try {
             const token = await loginUser(body.email, body.password);

--- a/src/services/users-service.js
+++ b/src/services/users-service.js
@@ -58,3 +58,21 @@ export const getUserById = async (id) => {
     const result = await db.select().from(users).where(eq(users.id, parseInt(id)));
     return result[0] || null;
 };
+
+export const getCurrentUser = async (token) => {
+    const [result] = await db.select({
+        id: users.id,
+        name: users.name,
+        email: users.email
+    })
+    .from(sessions)
+    .innerJoin(users, eq(sessions.userId, users.id))
+    .where(eq(sessions.token, token))
+    .limit(1);
+
+    if (!result) {
+        throw new Error("unauthorized");
+    }
+
+    return result;
+};


### PR DESCRIPTION
# Walkthrough: Get Current User

I've completed the implementation of the feature to retrieve the currently logged-in user's profile based on their session token.

## Features
- **Token Extraction**: Automatically extracts the Bearer token from the `Authorization` header.
- **Session Validation**: Validates the token against the `sessions` table using a database JOIN to ensure efficient retrieval.
- **Secure Data Response**: Returns only non-sensitive user fields: `id`, `name`, and `email`.
- **Unauthorized Handling**: Properly handles missing, malformed, or invalid tokens by returning a consistent `401 Unauthorized` response.

## Changes

### 1. Service Layer
Added the `getCurrentUser(token)` function to `src/services/users-service.js`. This function performing a JOIN between `sessions` and `users` to find the user profile associated with the provided token.

### 2. Route Layer
Updated `src/routes/users-route.js` to add the `GET /current` endpoint. This route handles:
-   Header extraction and validation.
-   Service calling within a `try-catch` block.
-   Consistent error response formatting.

## Verification Results

### Automated Tests
Verified using PowerShell's `Invoke-RestMethod`:
- **Authorized Request**: Successfully retrieved user profile data: `{"data": {"id": 1, "name": "Test User", "email": "test@example.com"}}`.
- **Invalid Token**: Correctly returned 401 Unauthorized when an invalid token was provided.
- **Missing Header**: Correctly returned 401 Unauthorized when the `Authorization` header was missing.

### Sample Request/Response
**Request**:
```bash
GET /api/users/current
Authorization: Bearer f3af2fe3-ffb1-4dc9-be26-90e836c84eb3
```

**Response (Success)**:
```json
{
    "data": {
        "id": 1,
        "name": "Test User",
        "email": "test@example.com"
    }
}
```

**Response (Error)**:
```json
{
    "error": "unauthorized"
}
```
*(Status Code: 401)*
