### PR TITLE
feat: implement delete current user endpoint

### DIFF
--- a/src/routes/users-route.js
+++ b/src/routes/users-route.js
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { registerUser, getAllUsers, getUserById, loginUser, getCurrentUser } from '../services/users-service.js';
+import { registerUser, getAllUsers, getUserById, loginUser, getCurrentUser, deleteCurrentUser } from '../services/users-service.js';
 
 export const usersRoute = new Elysia({ prefix: '/api/users' })
     .get('/current', async ({ request, set }) => {
@@ -15,6 +15,24 @@ export const usersRoute = new Elysia({ prefix: '/api/users' })
         try {
             const user = await getCurrentUser(token);
             return { data: user };
+        } catch (error) {
+            set.status = 401;
+            return { error: 'unauthorized' };
+        }
+    })
+    .delete('/current', async ({ request, set }) => {
+        const authHeader = request.headers.get('authorization');
+        
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+            set.status = 401;
+            return { error: 'unauthorized' };
+        }
+
+        const token = authHeader.split(' ')[1];
+
+        try {
+            const result = await deleteCurrentUser(token);
+            return { data: result };
         } catch (error) {
             set.status = 401;
             return { error: 'unauthorized' };

--- a/src/services/users-service.js
+++ b/src/services/users-service.js
@@ -76,3 +76,19 @@ export const getCurrentUser = async (token) => {
 
     return result;
 };
+
+export const deleteCurrentUser = async (token) => {
+    const [session] = await db.select().from(sessions).where(eq(sessions.token, token)).limit(1);
+
+    if (!session) {
+        throw new Error("unauthorized");
+    }
+
+    // Hapus semua sesi user ini
+    await db.delete(sessions).where(eq(sessions.userId, session.userId));
+
+    // Hapus user
+    await db.delete(users).where(eq(users.id, session.userId));
+
+    return { message: "user berhasil dihapus" };
+};


### PR DESCRIPTION
# Walkthrough: Delete Current User

I've completed the implementation of the feature to delete the currently logged-in user's account and all their session tokens.

## Features
- **Account Deletion**: Completely removes the user record and all associated session tokens from the database.
- **Security Check**: Only the authenticated user can delete their own account.
- **Token Validation**: Uses the Bearer token in the `Authorization` header for identity verification.
- **Graceful Logout**: Deleting the account also clears all active sessions for that user, ensuring they are immediately logged out of all devices.

## Changes

### 1. Service Layer
Added the `deleteCurrentUser(token)` function to `src/services/users-service.js`. This function:
-   Finds the user's ID from the session token.
-   Deletes all sessions for that user.
-   Deletes the user from the database.
-   Returns a success message.

### 2. Route Layer
Updated `src/routes/users-route.js` to add the `DELETE /current` endpoint. This route handles the extraction of the token and calls the deletion service.

## Verification Results

### Automated Tests
Verified using PowerShell's `Invoke-RestMethod`:
- **Successful Accounts Deletion**: Registered a new test user, logged in, and successfully deleted the account with a 200 OK response: `{"data": {"message": "user berhasil dihapus"}}`.
- **Verify Destruction**: Attempted to use the same token after deletion, which correctly returned a 401 Unauthorized error.
- **Invalid Token Prevention**: Confirmed that requests with invalid or missing tokens are rejected with a 401 response.

### Sample Request/Response
**Request**:
```bash
DELETE /api/users/current
Authorization: Bearer <valid_token>
```

**Response (Success)**:
```json
{
    "data": {
        "message": "user berhasil dihapus"
    }
}
```

**Response (Error)**:
```json
{
    "error": "unauthorized"
}
```
*(Status Code: 401)*
